### PR TITLE
FIX: Check key validity before get message

### DIFF
--- a/Parser.py
+++ b/Parser.py
@@ -139,8 +139,8 @@ class Parser:
         try:
             self.parse()
             if self.mode != Mode.GENERATE:
-                self.getMessage()
                 self.realKey = strToBytes(self.key)
+                self.getMessage()
         except Error as e:
             print(e)
             exit(84)


### PR DESCRIPTION
In the parsing, we checked for the key validity after the get message but on the mouli this resulted by a timeout.